### PR TITLE
Provide basic select entitities to GreeExt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/custom_components/gree_ext/__init__.py
+++ b/custom_components/gree_ext/__init__.py
@@ -10,6 +10,7 @@ import logging
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import area_registry as ar, device_registry as dr, entity_registry as er, entity_platform as ep
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.gree.const import DOMAIN as GREE_DOMAIN
 from homeassistant.components.gree.climate import GreeClimateEntity
@@ -64,7 +65,7 @@ async def async_setup(hass, config):
     
     # Set up the select platform
     hass.async_create_task(
-        hass.helpers.discovery.async_load_platform("select", DOMAIN, {}, config)
+        async_load_platform(hass, "select", DOMAIN, {}, config)
     )
     
     # Return boolean to indicate that initialization was successfully.

--- a/custom_components/gree_ext/__init__.py
+++ b/custom_components/gree_ext/__init__.py
@@ -1,19 +1,14 @@
 """
 The "Gree climate extension" custom component.
-
 This component implements the different swing types not configurable with the built in climate.
-
 Configuration:
-
 To use the component you will need to add the following to your
 configuration.yaml file.
-
 gree_ext:
 """
-
 import logging
-
-from homeassistant.core import callback
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import area_registry as ar, device_registry as dr, entity_registry as er, entity_platform as ep
 from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.gree.const import DOMAIN as GREE_DOMAIN
@@ -24,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 
 # The domain of your component. Should be equal to the name of your component.
 DOMAIN = "gree_ext"
-
 
 async def async_setup(hass, config):
     """Setup our component."""
@@ -67,6 +61,11 @@ async def async_setup(hass, config):
                         entity.async_write_ha_state()
 	
     hass.services.async_register(DOMAIN, 'set_swing_mode_ext', async_set_swing_mode_ext)
+    
+    # Set up the select platform
+    hass.async_create_task(
+        hass.helpers.discovery.async_load_platform("select", DOMAIN, {}, config)
+    )
     
     # Return boolean to indicate that initialization was successfully.
     return True

--- a/custom_components/gree_ext/select.py
+++ b/custom_components/gree_ext/select.py
@@ -1,0 +1,157 @@
+"""Select platform for Gree extended swing modes."""
+import logging
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import device_registry as dr, entity_registry as er, entity_platform as ep
+from homeassistant.components.gree.const import DOMAIN as GREE_DOMAIN
+from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.gree.climate import GreeClimateEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "gree_ext"
+
+HORIZONTAL_SWING_OPTIONS = [
+    "Default",
+    "FullSwing",
+    "Left",
+    "LeftCenter",
+    "Center",
+    "RightCenter",
+    "Right",
+]
+
+VERTICAL_SWING_OPTIONS = [
+    "Default",
+    "FullSwing",
+    "FixedUpper",
+    "FixedUpperMiddle",
+    "FixedMiddle",
+    "FixedLowerMiddle",
+    "FixedLower",
+    "SwingUpper",
+    "SwingUpperMiddle",
+    "SwingMiddle",
+    "SwingLowerMiddle",
+    "SwingLower",
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Gree extended select entities from a config entry."""
+    _LOGGER.debug("Setting up Gree extended select entities")
+    
+    entities = []
+    
+    # Find all Gree climate entities
+    for platform in ep.async_get_platforms(hass, GREE_DOMAIN):
+        if platform.domain == CLIMATE_DOMAIN:
+            for entity_id, entity in platform.entities.items():
+                if isinstance(entity, GreeClimateEntity):
+                    _LOGGER.debug(f"Creating select entities for {entity_id}")
+                    # Create two select entities for each Gree climate
+                    entities.append(GreeHorizontalSwingSelect(hass, entity))
+                    entities.append(GreeVerticalSwingSelect(hass, entity))
+    
+    if entities:
+        async_add_entities(entities)
+        _LOGGER.info(f"Added {len(entities)} Gree swing select entities")
+    else:
+        _LOGGER.warning("No Gree climate entities found to create selects for")
+
+
+class GreeSwingSelectBase(SelectEntity):
+    """Base class for Gree swing select entities."""
+
+    def __init__(self, hass: HomeAssistant, climate_entity: GreeClimateEntity):
+        """Initialize the select."""
+        self.hass = hass
+        self._climate_entity = climate_entity
+        self._attr_should_poll = False
+        
+        # Link to the same device as the climate entity
+        self._attr_device_info = climate_entity.device_info
+        
+    async def async_added_to_hass(self):
+        """When entity is added to hass."""
+        # Listen to climate entity state changes to update our state
+        self.async_on_remove(
+            self._climate_entity.coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )
+        
+    @callback
+    def _handle_coordinator_update(self):
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class GreeHorizontalSwingSelect(GreeSwingSelectBase):
+    """Select entity for horizontal swing mode."""
+
+    def __init__(self, hass: HomeAssistant, climate_entity: GreeClimateEntity):
+        """Initialize the select."""
+        super().__init__(hass, climate_entity)
+        self._attr_options = HORIZONTAL_SWING_OPTIONS
+        self._attr_unique_id = f"{climate_entity.unique_id}_horizontal_swing"
+        self._attr_name = f"{climate_entity.name} Horizontal Swing"
+        self._attr_icon = "mdi:arrow-left-right"
+        
+    @property
+    def current_option(self) -> str:
+        """Return the current selected option."""
+        try:
+            device = self._climate_entity.coordinator.device
+            return device.horizontal_swing.name
+        except (AttributeError, KeyError):
+            return "Default"
+    
+    async def async_select_option(self, option: str):
+        """Change the selected option."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_swing_mode_ext",
+            {
+                "entity_id": [self._climate_entity.entity_id],
+                "swing_mode_horizontal": option,
+            },
+        )
+
+
+class GreeVerticalSwingSelect(GreeSwingSelectBase):
+    """Select entity for vertical swing mode."""
+
+    def __init__(self, hass: HomeAssistant, climate_entity: GreeClimateEntity):
+        """Initialize the select."""
+        super().__init__(hass, climate_entity)
+        self._attr_options = VERTICAL_SWING_OPTIONS
+        self._attr_unique_id = f"{climate_entity.unique_id}_vertical_swing"
+        self._attr_name = f"{climate_entity.name} Vertical Swing"
+        self._attr_icon = "mdi:arrow-up-down"
+        
+    @property
+    def current_option(self) -> str:
+        """Return the current selected option."""
+        try:
+            device = self._climate_entity.coordinator.device
+            return device.vertical_swing.name
+        except (AttributeError, KeyError):
+            return "Default"
+    
+    async def async_select_option(self, option: str):
+        """Change the selected option."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_swing_mode_ext",
+            {
+                "entity_id": [self._climate_entity.entity_id],
+                "swing_mode_vertical": option,
+            },
+        )

--- a/custom_components/gree_ext/select.py
+++ b/custom_components/gree_ext/select.py
@@ -2,9 +2,8 @@
 import logging
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers import device_registry as dr, entity_registry as er, entity_platform as ep
+from homeassistant.helpers import entity_platform as ep
 from homeassistant.components.gree.const import DOMAIN as GREE_DOMAIN
 from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.gree.climate import GreeClimateEntity
@@ -39,22 +38,22 @@ VERTICAL_SWING_OPTIONS = [
 ]
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up Gree extended select entities from a config entry."""
-    _LOGGER.debug("Setting up Gree extended select entities")
+async def async_setup_platform(
+    hass: HomeAssistant, config, async_add_entities: AddEntitiesCallback, discovery_info=None
+):
+    """Set up Gree extended select entities."""
+    _LOGGER.info("Setting up Gree extended select platform")
     
     entities = []
     
     # Find all Gree climate entities
     for platform in ep.async_get_platforms(hass, GREE_DOMAIN):
+        _LOGGER.debug(f"Found platform: {platform.domain}")
         if platform.domain == CLIMATE_DOMAIN:
+            _LOGGER.info(f"Found Gree climate platform with {len(platform.entities)} entities")
             for entity_id, entity in platform.entities.items():
                 if isinstance(entity, GreeClimateEntity):
-                    _LOGGER.debug(f"Creating select entities for {entity_id}")
+                    _LOGGER.info(f"Creating select entities for {entity_id}")
                     # Create two select entities for each Gree climate
                     entities.append(GreeHorizontalSwingSelect(hass, entity))
                     entities.append(GreeVerticalSwingSelect(hass, entity))


### PR DESCRIPTION
Hi,

This addition provides basic select entitites to set swing modes. I tested this locally with my own machine and it works. 

Two caveats: it does not read the current state, it does allow you to set them though.

<img width="1028" height="263" alt="image" src="https://github.com/user-attachments/assets/72e23fe9-ebb5-46ac-9f02-10b23aca1843" />

<img width="1062" height="178" alt="image" src="https://github.com/user-attachments/assets/68edbf60-6bbf-46dc-b943-ef4b3e3ccaaa" />


<img width="673" height="534" alt="image" src="https://github.com/user-attachments/assets/602e4431-085a-43f3-aec4-9557950ce30e" />

<img width="731" height="781" alt="image" src="https://github.com/user-attachments/assets/f1a54969-5007-4369-9b9f-cb4d49b12fea" />
