### PR TITLE
Add UI setup and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Allows setting different swing positions for the default Gree integration.
 
 ## Custom Component Installation
 
-1. Copy the custom_components folder to your own hass `/config` folder.
+1. Copy the `custom_components` folder to your own hass `/config` folder.
 
-2. In your configuration.yaml add the following:
-  
-   ```yaml
-   gree_ext:
-   ```
+2. Restart Home Assistant.
+
+3. Go to **Settings → Devices & Services → Add Integration** and search for **Gree Climate Extension**.
+
+4. Click **Submit** to finish setup.
+
 ## Usage
 
 ### Select entities

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,2 +1,0 @@
-# Add this to your config to enable
-gree_ext:

--- a/custom_components/gree_ext/__init__.py
+++ b/custom_components/gree_ext/__init__.py
@@ -1,41 +1,31 @@
-"""
-The "Gree climate extension" custom component.
-
-This component implements the different swing types not configurable with the built in climate.
-
-Configuration:
-
-To use the component you will need to add the following to your
-configuration.yaml file.
-
-gree_ext:
-"""
+"""The "Gree climate extension" custom component."""
 
 import logging
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers import device_registry as dr
-from .const import DOMAIN, GREE_DOMAIN, SERVICE_SET_SWING_MODE_EXT
+from homeassistant.config_entries import ConfigEntry
+from .const import DOMAIN, SERVICE_SET_SWING_MODE_EXT
 from .service import async_set_swing_mode_ext
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup(hass: HomeAssistant, config):
-    """Setup our component."""
 
-    # Set up the service
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Gree Climate Extension from a config entry."""
+
     @callback
     async def async_set_swing_mode_ext_callback(call):
         """Set swing mode extended."""
         await async_set_swing_mode_ext(hass, call)
-	
+
     hass.services.async_register(DOMAIN, SERVICE_SET_SWING_MODE_EXT, async_set_swing_mode_ext_callback)
 
-    # Set up the select platform
-    hass.async_create_task(
-        async_load_platform(hass, "select", DOMAIN, {}, config)
-    )
-    
-    # Return boolean to indicate that initialization was successfully.
+    await hass.config_entries.async_forward_entry_setups(entry, ["select"])
+
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    hass.services.async_remove(DOMAIN, SERVICE_SET_SWING_MODE_EXT)
+    return await hass.config_entries.async_unload_platforms(entry, ["select"])

--- a/custom_components/gree_ext/config_flow.py
+++ b/custom_components/gree_ext/config_flow.py
@@ -1,0 +1,18 @@
+from homeassistant import config_entries
+from .const import DOMAIN
+
+
+class GreeExtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Gree Climate Extension."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(title="Gree Climate Extension", data={})
+
+        return self.async_show_form(step_id="user")

--- a/custom_components/gree_ext/manifest.json
+++ b/custom_components/gree_ext/manifest.json
@@ -2,10 +2,11 @@
   "domain": "gree_ext",
   "name": "Gree climate extension",
   "codeowners": ["@mullerdavid"],
+  "config_flow": true,
   "dependencies": ["gree"],
   "documentation": "https://github.com/mullerdavid/hass_GreeExt",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mullerdavid/hass_GreeExt/issues",
   "requirements": [],
-  "version": "0.9.0"
+  "version": "1.0.0"
 }

--- a/custom_components/gree_ext/select.py
+++ b/custom_components/gree_ext/select.py
@@ -1,23 +1,24 @@
 import logging
 
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import entity_platform as ep
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.gree.climate import GreeClimateEntity
 from greeclimate.device import HorizontalSwing, VerticalSwing
-from .const import DOMAIN, GREE_DOMAIN, CLIMATE_DOMAIN, SERVICE_SET_SWING_MODE_EXT, HORIZONTAL_SWING_OPTIONS, VERTICAL_SWING_OPTIONS
+from .const import DOMAIN, GREE_DOMAIN, CLIMATE_DOMAIN, HORIZONTAL_SWING_OPTIONS, VERTICAL_SWING_OPTIONS
 from .helpers import get_climate_base_name, set_entity_swing_mode
 
 # Based on the PR by [Ian C.](https://github.com/ic-dev21). Thank you.
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_platform(
-    hass: HomeAssistant, config, async_add_entities: AddEntitiesCallback, discovery_info=None
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    """Set up Gree extended select entities."""
+    """Set up Gree extended select entities from a config entry."""
     _LOGGER.info("Setting up Gree extended select platform")
 
     select_entities: dict[str, list] = {}
@@ -106,6 +107,7 @@ class GreeHorizontalSwingSelect(GreeSwingSelectBase):
         self._attr_unique_id = f"{climate_entity.unique_id}_horizontal_swing"
         self._attr_name = f"{self._base_name} Horizontal Swing"
         self._attr_icon = "mdi:arrow-left-right"
+        self._attr_translation_key = "horizontal_swing"
 
     @property
     def current_option(self) -> str:
@@ -142,6 +144,7 @@ class GreeVerticalSwingSelect(GreeSwingSelectBase):
         self._attr_unique_id = f"{climate_entity.unique_id}_vertical_swing"
         self._attr_name = f"{self._base_name} Vertical Swing"
         self._attr_icon = "mdi:arrow-up-down"
+        self._attr_translation_key = "vertical_swing"
 
     @property
     def current_option(self) -> str:

--- a/custom_components/gree_ext/strings.json
+++ b/custom_components/gree_ext/strings.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Gree Climate Extension",
+        "description": "Set up the Gree Climate Extension integration to enable extended swing control for your Gree devices."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Already configured. Only a single configuration is possible."
+    }
+  },
+  "entity": {
+    "select": {
+      "horizontal_swing": {
+        "state": {
+          "Default": "Default",
+          "FullSwing": "Full Swing",
+          "Left": "Left",
+          "LeftCenter": "Left Center",
+          "Center": "Center",
+          "RightCenter": "Right Center",
+          "Right": "Right"
+        }
+      },
+      "vertical_swing": {
+        "state": {
+          "Default": "Default",
+          "FullSwing": "Full Swing",
+          "FixedUpper": "Fixed Upper",
+          "FixedUpperMiddle": "Fixed Upper Middle",
+          "FixedMiddle": "Fixed Middle",
+          "FixedLowerMiddle": "Fixed Lower Middle",
+          "FixedLower": "Fixed Lower",
+          "SwingUpper": "Swing Upper",
+          "SwingUpperMiddle": "Swing Upper Middle",
+          "SwingMiddle": "Swing Middle",
+          "SwingLowerMiddle": "Swing Lower Middle",
+          "SwingLower": "Swing Lower"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/gree_ext/translations/en.json
+++ b/custom_components/gree_ext/translations/en.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Gree Climate Extension",
+        "description": "Set up the Gree Climate Extension integration to enable extended swing control for your Gree devices."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Already configured. Only a single configuration is possible."
+    }
+  },
+  "entity": {
+    "select": {
+      "horizontal_swing": {
+        "state": {
+          "Default": "Default",
+          "FullSwing": "Full Swing",
+          "Left": "Left",
+          "LeftCenter": "Left Center",
+          "Center": "Center",
+          "RightCenter": "Right Center",
+          "Right": "Right"
+        }
+      },
+      "vertical_swing": {
+        "state": {
+          "Default": "Default",
+          "FullSwing": "Full Swing",
+          "FixedUpper": "Fixed Upper",
+          "FixedUpperMiddle": "Fixed Upper Middle",
+          "FixedMiddle": "Fixed Middle",
+          "FixedLowerMiddle": "Fixed Lower Middle",
+          "FixedLower": "Fixed Lower",
+          "SwingUpper": "Swing Upper",
+          "SwingUpperMiddle": "Swing Upper Middle",
+          "SwingMiddle": "Swing Middle",
+          "SwingLowerMiddle": "Swing Lower Middle",
+          "SwingLower": "Swing Lower"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/gree_ext/translations/hu.json
+++ b/custom_components/gree_ext/translations/hu.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Gree Climate Extension",
+        "description": "A Gree Climate Extension integráció beállítása a Gree eszközök kiterjesztett légirány-vezérlésének engedélyezéséhez."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Már konfigurálva. Csak egyetlen konfiguráció lehetséges."
+    }
+  },
+  "entity": {
+    "select": {
+      "horizontal_swing": {
+        "state": {
+          "Default": "Alapértelmezett",
+          "FullSwing": "Teljes vízszintes mozgás",
+          "Left": "Bal",
+          "LeftCenter": "Bal-közép",
+          "Center": "Közép",
+          "RightCenter": "Jobb-közép",
+          "Right": "Jobb"
+        }
+      },
+      "vertical_swing": {
+        "state": {
+          "Default": "Alapértelmezett",
+          "FullSwing": "Teljes függőleges mozgás",
+          "FixedUpper": "Rögzített felső",
+          "FixedUpperMiddle": "Rögzített felső-közép",
+          "FixedMiddle": "Rögzített közép",
+          "FixedLowerMiddle": "Rögzített alsó-közép",
+          "FixedLower": "Rögzített alsó",
+          "SwingUpper": "Lengő felső",
+          "SwingUpperMiddle": "Lengő felső-közép",
+          "SwingMiddle": "Lengő közép",
+          "SwingLowerMiddle": "Lengő alsó-közép",
+          "SwingLower": "Lengő alsó"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Migrates to UI based setup.
- Also allow translating the swing options.

Changes made with Claude Code, and tested manually.
<img width="1116" height="807" alt="image" src="https://github.com/user-attachments/assets/36e5b3d6-11c3-49fc-8180-6fa552fb0e48" />
<img width="279" height="580" alt="image" src="https://github.com/user-attachments/assets/b4ede31d-6d0c-4598-9b4a-229ec046c024" />

Trying to setup the second time:
<img width="649" height="237" alt="image" src="https://github.com/user-attachments/assets/f943420e-7355-4616-91c5-9b15bed54a05" />
